### PR TITLE
Add namespace 'speeches' to all templates

### DIFF
--- a/speeches/models.py
+++ b/speeches/models.py
@@ -78,11 +78,11 @@ class Speaker(InstanceMixin, AuditedModel):
 
     @models.permalink
     def get_absolute_url(self):
-        return ( 'speaker-view', (), { 'pk': self.id } )
+        return ( 'speeches:speaker-view', (), { 'pk': self.id } )
 
     @models.permalink
     def get_edit_url(self):
-        return ( 'speaker-edit', (), { 'pk': self.id } )
+        return ( 'speeches:speaker-edit', (), { 'pk': self.id } )
 
     # http://stackoverflow.com/a/5772272/669631
     def save(self, *args, **kwargs):
@@ -321,15 +321,15 @@ class Section(AuditedModel, InstanceMixin):
 
     @models.permalink
     def get_absolute_url(self):
-        return ( 'section-view', (), { 'pk': self.id } )
+        return ( 'speeches:section-view', (), { 'pk': self.id } )
 
     @models.permalink
     def get_edit_url(self):
-        return ( 'section-edit', (), { 'pk': self.id } )
+        return ( 'speeches:section-edit', (), { 'pk': self.id } )
 
     @models.permalink
     def get_delete_url(self):
-        return ( 'section-delete', (), { 'pk': self.id } )
+        return ( 'speeches:section-delete', (), { 'pk': self.id } )
 
     def _get_next_previous_node(self, direction):
         if not self.parent:
@@ -471,15 +471,15 @@ class Speech(InstanceMixin, AudioMP3Mixin, AuditedModel):
 
     @models.permalink
     def get_absolute_url(self):
-        return ( 'speech-view', (), { 'pk': self.id } )
+        return ( 'speeches:speech-view', (), { 'pk': self.id } )
 
     @models.permalink
     def get_edit_url(self):
-        return ( 'speech-edit', (), { 'pk': self.id } )
+        return ( 'speeches:speech-edit', (), { 'pk': self.id } )
 
     @models.permalink
     def get_delete_url(self):
-        return ( 'speech-delete', (), { 'pk': self.id } )
+        return ( 'speeches:speech-delete', (), { 'pk': self.id } )
 
     def get_next_speech(self):
         """Return the next speech to this one in the same section, in a start
@@ -592,7 +592,7 @@ class Recording(InstanceMixin, AudioMP3Mixin, AuditedModel):
 
     @models.permalink
     def get_absolute_url(self):
-        return ( 'recording-view', (), { 'pk': self.id } )
+        return ( 'speeches:recording-view', (), { 'pk': self.id } )
 
     def add_speeches_to_section(self, section):
         return Speech.objects.filter(recordingtimestamp__recording=self).update(section=section)

--- a/speeches/templates/speeches/recording_detail.html
+++ b/speeches/templates/speeches/recording_detail.html
@@ -25,7 +25,7 @@
       {% with ts.speech as speech %}
         {% if not speech.is_public %}<span class="label label-info">Invisible</span>{% endif %}
         <span class="speech-speaker"> <strong>{{ speech.speaker|default_if_none:"Unknown Speaker" }}</strong></span>
-        <span class="speech-summary"> said <a href="{%url "speech-view" speech.id%}"><em>&#8220;{{ speech.summary}}&#8221;</em></a></span>
+        <span class="speech-summary"> said <a href="{% url "speeches:speech-view" speech.id%}"><em>&#8220;{{ speech.summary}}&#8221;</em></a></span>
         <span class="speech-date muted"><small>{{ speech.start_date|default_if_none:"Undated" }} </small></span>
         <audio class="audio-small" id="audio-speech{{ speech.id }}" src="{{ MEDIA_URL }}{{ speech.audio }}" controls></audio>
         <script>
@@ -43,7 +43,7 @@
 <h2>{% trans "Actions" %}</h2>
 
     <input type="button" value="Edit Timestamps" id="edit-timestamps"
-        onClick="window.location='{%url "recording-edit" recording.id%}'">
+        onClick="window.location='{% url "speeches:recording-edit" recording.id%}'">
 
 <form class="form-horizontal" method="post">
     {% include 'speeches/form.html' with submit="Update" type="recording" %}

--- a/speeches/templates/speeches/section_detail.html
+++ b/speeches/templates/speeches/section_detail.html
@@ -10,7 +10,7 @@
 <div class="page-header">
 
     <ul class="breadcrumbs">
-        <li><a href="{% url 'section-list' %}">{% trans "Sections" %}</a> <span class="divider">&rarr;</span></li>
+        <li><a href="{% url 'speeches:section-list' %}">{% trans "Sections" %}</a> <span class="divider">&rarr;</span></li>
     {% for n in section.get_ancestors %}
     {% if n.id != section.id %}
         <li><a href="{{ n.get_absolute_url }}">{{ n.title }}</a> <span class="divider">&rarr;</span></li>
@@ -27,8 +27,8 @@
       <ul class="dropdown-menu">
         <li><a href="{{ section.get_edit_url }}">{% trans "Edit section" %}</a>
         <li><a href="{{ section.get_delete_url }}">{% trans "Delete section" %}</a>
-        <li><a href="{% url "section-add" %}?section={{ section.id }}">{% trans "Add a new subsection" %}</a>
-        <li><a href="{% url "speech-add" %}?section={{ section.id }}">{% trans "Add a new speech" %}</a>
+        <li><a href="{% url "speeches:section-add" %}?section={{ section.id }}">{% trans "Add a new subsection" %}</a>
+        <li><a href="{% url "speeches:speech-add" %}?section={{ section.id }}">{% trans "Add a new speech" %}</a>
       </ul>
     </div>
     {% endif %}
@@ -41,10 +41,10 @@
   {% if previous or next %}
     <ul class="pager">
       {% if previous %}
-        <li class="previous"><a href="{% url "section-view" previous.id %}">&larr; {{ previous.title }}</a>
+        <li class="previous"><a href="{% url "speeches:section-view" previous.id %}">&larr; {{ previous.title }}</a>
       {% endif %}
       {% if next %}
-        <li class="next"><a href="{% url "section-view" next.id %}">{{ next.title }} &rarr;</a>
+        <li class="next"><a href="{% url "speeches:section-view" next.id %}">{{ next.title }} &rarr;</a>
       {% endif %}
     </ul>
   {% endif %}
@@ -66,10 +66,10 @@
   {% if previous or next %}
     <ul class="pager">
       {% if previous %}
-        <li class="previous"><a href="{% url "section-view" previous.id %}">&larr; {{ previous.title }}</a>
+        <li class="previous"><a href="{% url "speeches:section-view" previous.id %}">&larr; {{ previous.title }}</a>
       {% endif %}
       {% if next %}
-        <li class="next"><a href="{% url "section-view" next.id %}">{{ next.title }} &rarr;</a>
+        <li class="next"><a href="{% url "speeches:section-view" next.id %}">{{ next.title }} &rarr;</a>
       {% endif %}
     </ul>
   {% endif %}

--- a/speeches/templates/speeches/section_list.html
+++ b/speeches/templates/speeches/section_list.html
@@ -14,7 +14,7 @@
 <ul class="unstyled">
     {% for top in object_list %}
     <li>
-        <span class="section-title"><a href="{% url "section-view" top.id %}">{{ top.title }}</a></span>
+        <span class="section-title"><a href="{% url "speeches:section-view" top.id %}">{{ top.title }}</a></span>
     </li>
     {% endfor %}
 </ul>

--- a/speeches/templates/speeches/speaker_detail.html
+++ b/speeches/templates/speeches/speaker_detail.html
@@ -25,7 +25,7 @@
         </a>
         <ul class="dropdown-menu">
           <li><a href="{{ speaker.get_edit_url }}">{% trans "Edit speaker" %}</a>
-          <li><a href="{% url "speech-add" %}?speaker={{ speaker.id }}">{% trans "Add a new speech" %}</a>
+          <li><a href="{% url "speeches:speech-add" %}?speaker={{ speaker.id }}">{% trans "Add a new speech" %}</a>
         </ul>
     </div>
   {% endif %}

--- a/speeches/templates/speeches/speech.html
+++ b/speeches/templates/speeches/speech.html
@@ -50,9 +50,9 @@
   {% endfor %}
 
   {% if speech.section_id %}
-    <a class="hov" title="{% trans "Permalink to this speech in context" %}" href="{% url 'section-view' speech.section_id %}#s{{ speech.id }}"><i class="icon-tags off-screen">{% trans "Permalink to this speech in context" %}</i></a>
+    <a class="hov" title="{% trans "Permalink to this speech in context" %}" href="{% url 'speeches:section-view' speech.section_id %}#s{{ speech.id }}"><i class="icon-tags off-screen">{% trans "Permalink to this speech in context" %}</i></a>
   {% endif %}
-    <a class="hov" title="{% trans "Permalink to this speech individually" %}" href="{% url "speech-view" speech.id %}"><i class="icon-tag off-screen">{% trans "Permalink to this speech individually" %}</i></a>
+    <a class="hov" title="{% trans "Permalink to this speech individually" %}" href="{% url "speeches:speech-view" speech.id %}"><i class="icon-tag off-screen">{% trans "Permalink to this speech individually" %}</i></a>
   {% if speech.audio %}
     <i class="icon-volume-up off-screen">{% trans "This speech has audio" %}</i>
     <audio class="audio-small" id="audio{{ speech.id }}" src="{{ MEDIA_URL }}{{ speech.audio }}" controls></audio>

--- a/speeches/templates/speeches/speech_detail.html
+++ b/speeches/templates/speeches/speech_detail.html
@@ -58,7 +58,7 @@
     <p class="lead muted">
         <small>Statement made by </small>
         {% if object.speaker %}
-            <a href="{% url "speaker-view" object.speaker.id %}">{{ object.speaker }}</a>
+            <a href="{% url "speeches:speaker-view" object.speaker.id %}">{{ object.speaker }}</a>
         {% else %}
             Unknown speaker
         {% endif %}
@@ -80,10 +80,10 @@
   {% if previous or next %}
     <ul class="pager">
       {% if previous %}
-        <li class="previous"><a href="{% url "speech-view" previous.id %}">&larr; {{ previous.summary|bleach }}</a>
+        <li class="previous"><a href="{% url "speeches:speech-view" previous.id %}">&larr; {{ previous.summary|bleach }}</a>
       {% endif %}
       {% if next %}
-        <li class="next"><a href="{% url "speech-view" next.id %}">{{ next.summary|bleach }} &rarr;</a>
+        <li class="next"><a href="{% url "speeches:speech-view" next.id %}">{{ next.summary|bleach }} &rarr;</a>
       {% endif %}
     </ul>
   {% endif %}

--- a/speeches/templates/speeches/speech_form.html
+++ b/speeches/templates/speeches/speech_form.html
@@ -22,8 +22,8 @@
 
 {% if added %}
 <div class="alert alert-success"> 
-    Your speech has been <a href="{% url "speech-view" added %}">created</a>
-    in the section <a href="{% url "section-view" section.id %}#s{{ added }}">{{ section.title }}</a>!
+    Your speech has been <a href="{% url "speeches:speech-view" added %}">created</a>
+    in the section <a href="{% url "speeches:section-view" section.id %}#s{{ added }}">{{ section.title }}</a>!
 </div>
 {% endif %}
 

--- a/speeches/templates/speeches/speech_list.html
+++ b/speeches/templates/speeches/speech_list.html
@@ -17,7 +17,7 @@
 		<li>
 			<h3>
 				{% if speech.grouper %}
-					<a href="{% url "speaker-view" speech.grouper.id %}">{{ speech.grouper }}</a>
+					<a href="{% url "speeches:speaker-view" speech.grouper.id %}">{{ speech.grouper }}</a>
 				{% else %}
 					No Speaker
 				{% endif %}

--- a/speeches/views.py
+++ b/speeches/views.py
@@ -76,7 +76,7 @@ class SpeechMixin(InstanceFormMixin):
         return form
 
 class SpeechDelete(SpeechMixin, DeleteView):
-    success_url = reverse_lazy('speech-list')
+    success_url = reverse_lazy('speeches:speech-list')
 
 class SpeechCreate(SpeechMixin, CreateView):
     def get_context_data(self, **kwargs):
@@ -169,7 +169,7 @@ class SpeechCreate(SpeechMixin, CreateView):
         self.object.start_transcribing()
 
         if 'add_another' in self.request.POST:
-            url = reverse('speech-add')
+            url = reverse('speeches:speech-add')
             speech = self.object
             if speech.section_id:
                 url = url + '?section=%d&added=%d' % (speech.section_id, speech.id)
@@ -248,7 +248,7 @@ class SpeakerUpdate(SpeakerMixin, UpdateView):
 class SpeakerPopit(InstanceFormMixin, FormView):
     template_name = 'speeches/speaker_popit.html'
     form_class = SpeakerPopitForm
-    success_url = reverse_lazy('speaker-popit')
+    success_url = reverse_lazy('speeches:speaker-popit')
 
     def form_valid(self, form):
         ai, _ = ApiInstance.objects.get_or_create(url=form.cleaned_data['url'])
@@ -310,7 +310,7 @@ class SectionUpdate(SectionMixin, UpdateView):
     pass
 
 class SectionDelete(SectionMixin, DeleteView):
-    success_url = reverse_lazy('section-list')
+    success_url = reverse_lazy('speeches:section-list')
 
 class SectionView(InstanceViewMixin, DetailView):
     model = Section
@@ -444,7 +444,7 @@ class RecordingAPICreate(InstanceFormMixin, JSONResponseMixin, CreateView):
         serialisable_fields = ('audio', 'timestamps')
         serialised = serializers.serialize("json", [recording], fields=serialisable_fields)
         serialised = serialised[1:-1]
-        return self.render_to_response(serialised, status=201, location=reverse("recording-view", args=[recording.id]))
+        return self.render_to_response(serialised, status=201, location=reverse("speeches:recording-view", args=[recording.id]))
 
     def form_invalid(self, form):
         return self.render_to_response({ 'errors': json.dumps(form.errors) }, status=400)

--- a/spoke/templates/base.html
+++ b/spoke/templates/base.html
@@ -61,9 +61,9 @@
                 <div class="nav-collapse collapse">
                     <ul class="nav">
                       {% if request.instance %}
-                        <li{% if request.path == '/speakers' %} class="active"{% endif %}><a href="{% url 'speaker-list' %}"><b>Speakers</b></a>
-                        <li{% if request.path == '/speeches' %} class="active"{% endif %}><a href="{% url 'speech-list' %}"><b>Speeches</b></a>
-                        <li{% if request.path == '/sections' %} class="active"{% endif %}><a href="{% url 'section-list' %}"><b>Sections</b></a>
+                        <li{% if request.path == '/speakers' %} class="active"{% endif %}><a href="{% url 'speeches:speaker-list' %}"><b>Speakers</b></a>
+                        <li{% if request.path == '/speeches' %} class="active"{% endif %}><a href="{% url 'speeches:speech-list' %}"><b>Speeches</b></a>
+                        <li{% if request.path == '/sections' %} class="active"{% endif %}><a href="{% url 'speeches:section-list' %}"><b>Sections</b></a>
                       {% endif %}
                     </ul>
                     <ul class="nav pull-right">
@@ -72,14 +72,14 @@
                         <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">Instance <b class="caret"></b></a>
                         <ul class="dropdown-menu">
                           {% if request.is_user_instance %}
-                            <li{% if request.path == '/speech/add' %} class="active"{% endif %}><a href="{% url 'speech-add' %}">Add speech</a>
-                            <li{% if request.path == '/sections/add' %} class="active"{% endif %}><a href="{% url 'section-add' %}">Add section</a>
-                            <li{% if request.path == '/speaker/add' %} class="active"{% endif %}><a href="{% url 'speaker-add' %}">Add speaker</a>
-                            <li{% if request.path == '/speaker/popit' %} class="active"{% endif %}><a href="{% url 'speaker-popit' %}">Add PopIt instance</a>
+                            <li{% if request.path == '/speech/add' %} class="active"{% endif %}><a href="{% url 'speeches:speech-add' %}">Add speech</a>
+                            <li{% if request.path == '/sections/add' %} class="active"{% endif %}><a href="{% url 'speeches:section-add' %}">Add section</a>
+                            <li{% if request.path == '/speaker/add' %} class="active"{% endif %}><a href="{% url 'speeches:speaker-add' %}">Add speaker</a>
+                            <li{% if request.path == '/speaker/popit' %} class="active"{% endif %}><a href="{% url 'speeches:speaker-popit' %}">Add PopIt instance</a>
                             <li{% if request.path == '/instance/edit' %} class="active"{% endif %}>
                                 <a href="{% url 'instance-edit' %}">{% trans "Edit instance" %}</a>
                             </li>
-                            <li{% if request.path == '/recordings' %} class="active"{% endif %}><a href="{% url 'recording-list' %}">Your recordings</a>
+                            <li{% if request.path == '/recordings' %} class="active"{% endif %}><a href="{% url 'speeches:recording-list' %}">Your recordings</a>
                             <li{% if request.path == '/instance/token' %} class="active"{% endif %}>
                                 <a href="{% url 'tokens' %}">{% trans "Your token" %}</a>
                             </li>

--- a/spoke/urls.py
+++ b/spoke/urls.py
@@ -14,7 +14,7 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
     
-    url(r'^', include('speeches.urls')),
+    url(r'^', include('speeches.urls', app_name='speeches', namespace='speeches')),
 
     url(r'^accounts/login/$', 'django.contrib.auth.views.login'),
     url(r'^accounts/logout/$', 'django.contrib.auth.views.logout'),


### PR DESCRIPTION
This will support other applications, such as pombola including
speeches with a speeches namespace, allowing them to include
all or part of app under a different url conf.  An example of
including the namespaced urls is in spoke/templates/base.html
