### PR TITLE
Split breadcrumbs into their own template include

### DIFF
--- a/speeches/templates/speeches/_breadcrumbs.html
+++ b/speeches/templates/speeches/_breadcrumbs.html
@@ -1,0 +1,10 @@
+{% load url from future %}
+
+<ul class="breadcrumbs">
+    <li><a href="{% url 'speeches:section-list' %}">{% trans "Sections" %}</a> <span class="divider">&rarr;</span></li>
+{% for n in section.get_ancestors %}
+{% if n.id != section.id %}
+    <li><a href="{{ n.get_absolute_url }}">{{ n.title }}</a> <span class="divider">&rarr;</span></li>
+{% endif %}
+{% endfor %}
+</ul>

--- a/speeches/templates/speeches/section_detail.html
+++ b/speeches/templates/speeches/section_detail.html
@@ -9,14 +9,7 @@
 
 <div class="page-header">
 
-    <ul class="breadcrumbs">
-        <li><a href="{% url 'speeches:section-list' %}">{% trans "Sections" %}</a> <span class="divider">&rarr;</span></li>
-    {% for n in section.get_ancestors %}
-    {% if n.id != section.id %}
-        <li><a href="{{ n.get_absolute_url }}">{{ n.title }}</a> <span class="divider">&rarr;</span></li>
-    {% endif %}
-    {% endfor %}
-    </ul>
+    {% include "speeches/_breadcrumbs.html" %}
 
     {% if user.is_authenticated %}
     <div class="btn-group pull-right">


### PR DESCRIPTION
This makes it easier to override the template in applications that use the speeches app, such as Pombola, without having to override the whole parent template.

Related to https://github.com/mysociety/pombola/issues/913
