### PR TITLE
Fix unattached speeches CSS bugs

### DIFF
--- a/speeches/templates/speeches/section_list.html
+++ b/speeches/templates/speeches/section_list.html
@@ -38,7 +38,7 @@
             <ul class="unstyled js-masonry" data-masonry-options='{"columnWidth":".speech","itemSelector":".speech","gutter":".gutter-sizer"}'>
                 <li class="gutter-sizer"></li>
               {% for speech in speech_list %}
-                {% include "speeches/speech.html" with speech=speech nosection="1" truncate="1" %}
+                {% include "speeches/speech.html" with speech=speech nosection="1" standalone="1" truncate="1" %}
               {% endfor %}
             </ul>
         </div>

--- a/speeches/templates/speeches/speech.html
+++ b/speeches/templates/speeches/speech.html
@@ -4,7 +4,7 @@
 {% load speech_utils %}
 
 {% if not noli %}
-<li id="s{{ speech.id }}" class="speech {% if result.object %}speech--search-result{% endif %} {% if speech.speaker and not nospeaker %}speech--with-portrait{% endif %} {% if not speech.speaker  %}speech--narrative{% endif %} speech--border"
+<li id="s{{ speech.id }}" class="speech {% if result.object %}speech--search-result{% endif %} {% if speech.speaker and not nospeaker and not standalone %}speech--with-portrait{% endif %} {% if not speech.speaker  %}speech--narrative{% endif %} speech--border"
 {% if speech.speaker.colour %} style="border-left-color: #{{ speech.speaker.colour }};"{% endif %}>
 {% endif %}
 
@@ -12,7 +12,7 @@
     <span class="label label-info">{% trans "Invisible" %}</span>
   {% endif %}
 
-  {% if not nospeaker %}
+  {% if not nospeaker and not standalone %}
     {% if speech.speaker %}
     <div class="speaker-portrait-wrapper">
     <img src="{% if speech.speaker.person.image %}


### PR DESCRIPTION
I've added masonry to the required page, which fixes the grid issues.

And I've made a new `standalone="1"` option for the `speeches/speech.html` template, which lets you disable the speaker avatar and left-hand vertical line for speeches which you _know_ aren't meant to be attached to the speeches above or below them.

![screen shot 2014-05-08 at 18 00 25](https://cloud.githubusercontent.com/assets/739624/2918632/4aa53132-d6d2-11e3-8f53-7e68fd571323.png)
