### PR TITLE
Support coverPage as an alternative to preface

### DIFF
--- a/speeches/importers/import_akomantoso.py
+++ b/speeches/importers/import_akomantoso.py
@@ -50,9 +50,9 @@ class ImportAkomaNtoso (ImporterBase):
             self.speakers[id] = speaker
 
         if self.ns:
-            docDate = debate.find('an:preface//an:docDate', namespaces={'an': self.ns})
+            docDate = debate.find('an:coverPage//an:docDate|an:preface//an:docDate', namespaces={'an': self.ns})
         else:
-            docDate = debate.find('preface//docDate')
+            docDate = debate.find('coverPage//docDate|preface//docDate')
         if docDate is not None:
             self.start_date = dateutil.parse(docDate.get('date'))
 


### PR DESCRIPTION
`coverPage` has much the same semantics as `preface`, and there are many AN examples using `coverPage` instead of `preface` for the same information. In the documents I'm converting, the data is on a cover page, so I figure I should use the appropriate term. I think this just requires editing a few xpath selectors in the AN importer.
