### PR TITLE
Make example project easier to run

### DIFF
--- a/example_project/settings/pipeline.py
+++ b/example_project/settings/pipeline.py
@@ -31,8 +31,8 @@ STATICFILES_FINDERS = (
 )
 
 # Compress the css and js using yui-compressor.
-PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.yui.YUICompressor'
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.yui.YUICompressor'
+PIPELINE_CSS_COMPRESSOR = None
+PIPELINE_JS_COMPRESSOR = None
 PIPELINE_COMPILERS = (
     'pipeline_compass.compass.CompassCompiler',
 )


### PR DESCRIPTION
Don't create unnecessary barriers to get the example project running.
- No one needs asset compression in an example project. This avoids having to install yui-compressor.

Is ElasticSearch used by the demo or the tests? I know that `ffmpeg` and `libmagic` are needed for tests to pass.
