### PR TITLE
Log error instead of failing when there is an unknown Akoma Ntoso element

### DIFF
--- a/speeches/importers/import_akomantoso.py
+++ b/speeches/importers/import_akomantoso.py
@@ -141,4 +141,4 @@ class ImportAkomaNtoso (ImporterBase):
             else:
                 success = self.handle_tag(child, section)
                 if not success:
-                    raise Exception('%s unrecognised, "%s" - %s' % (child.tag, child, self.get_text(child)))
+                    logger.error('%s unrecognised, "%s" - %s' % (child.tag, child, self.get_text(child)))


### PR DESCRIPTION
For example, my Akoma Ntoso files have `recordedTime` tags. I'd rather the importer skip them (and log errors) than fail completely.

In this specific case, I suppose support for `recordedTime` can be eventually added (it's pretty much a narrative element).
