### PR TITLE
Sqlite3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 django.mo
 .apdisk
 .DS_Store
+db.sqlite3
 chromedriver.log
 *~
 .noseids

--- a/example_project/settings/base.py
+++ b/example_project/settings/base.py
@@ -24,12 +24,8 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'sayit-example-project',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(PROJECT_ROOT, 'db.sqlite3'),
     }
 }
 
@@ -251,7 +247,7 @@ from .thumbnails import *
 
 # Haystack search settings
 
-SEARCH_INDEX_NAME = DATABASES['default']['NAME']
+SEARCH_INDEX_NAME = 'sayit-example-project'
 if 'test' in sys.argv:
     SEARCH_INDEX_NAME += '_test'
 

--- a/speeches/models.py
+++ b/speeches/models.py
@@ -317,7 +317,7 @@ class Section(AuditedModel, InstanceMixin):
             s = s[1:]
         for node in s:
             node.path = [int(x) for x in node.path.split(',')]
-            if node.speech_min:
+            if hasattr(node, 'speech_min') and node.speech_min:
                 node.speech_min = datetime.datetime.strptime(node.speech_min, '%Y-%m-%d %H:%M:%S')
         return s
 

--- a/speeches/south_migrations/0007_auto__del_index_field_speech_text.py
+++ b/speeches/south_migrations/0007_auto__del_index_field_speech_text.py
@@ -9,9 +9,9 @@ class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Removing index on 'Speech', fields ['text']
-        db.delete_index('speeches_speech', ['text'])
+        db.execute('DROP INDEX IF EXISTS %s' % db.create_index_name('speeches_speech', ['text']))
         # Also remove the _like index
-        db.delete_index('speeches_speech', ['text_like'])
+        db.execute('DROP INDEX IF EXISTS %s' % db.create_index_name('speeches_speech', ['text_like']))
 
 
     def backwards(self, orm):

--- a/speeches/south_migrations/0023_auto__add_field_section_instance.py
+++ b/speeches/south_migrations/0023_auto__add_field_section_instance.py
@@ -6,6 +6,7 @@ from django.db import models
 
 
 class Migration(SchemaMigration):
+    no_dry_run = True
 
     depends_on = (
         ("instances", "0004_auto__add_field_instance_created_by"),

--- a/speeches/south_migrations/0051_move_speaker_data.py
+++ b/speeches/south_migrations/0051_move_speaker_data.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 from south.v2 import DataMigration
+from django.db import connection
 from django.utils.encoding import smart_text
+
+# set_autocommit was introduced in Django 1.6.
+try:
+    from django.db.transaction import set_autocommit
+    found_set_autocommit = True
+except ImportError:
+    found_set_autocommit = False
 
 # Note: Don't use "from appname.models import ModelName".
 # Use orm.ModelName to refer to models in this application,
@@ -32,6 +40,9 @@ class Migration(DataMigration):
     no_dry_run = True
 
     def forwards(self, orm):
+        if found_set_autocommit and connection.vendor == 'sqlite':
+            set_autocommit(True)
+
         old_ct = get_content_type(orm, 'speeches', 'speaker')
         new_ct = get_content_type(orm, 'speeches', 'popolospeaker')
         popolo_ct = get_content_type(orm, 'popolo', 'person')


### PR DESCRIPTION
Includes #296. Trying to fix #302.

Had to use `db.execute` instead of `db.remove_index` due to [a bug in South](http://south.aeracode.org/ticket/757).

Since I can't figure out how to update SQLite on Travis, here are the two failures and one error from my local machine. If these can't be fixed, I can back out the changes to `_get_descendants` and just get the other changes through in this PR.

```
======================================================================
ERROR: test_add_section_in_section (speeches.tests.section_tests.SectionSiteTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/james/Sites/shared/pulls/sayit/speeches/tests/section_tests.py", line 182, in test_add_section_in_section
    'title': 'A test subsection'
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/test/client.py", line 483, in post
    response = super(Client, self).post(path, data=data, content_type=content_type, **extra)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/test/client.py", line 302, in post
    return self.request(**r)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/test/client.py", line 444, in request
    six.reraise(*exc_info)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/utils/decorators.py", line 29, in _wrapper
    return bound_func(*args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/instances/views.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/utils/decorators.py", line 25, in bound_func
    return func(self, *args2, **kwargs2)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/instances/views.py", line 31, in dispatch
    return super(InstanceFormMixin, self).dispatch(*args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/base.py", line 87, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/edit.py", line 205, in post
    return super(BaseCreateView, self).post(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/edit.py", line 170, in post
    if form.is_valid():
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 129, in is_valid
    return self.is_bound and not bool(self.errors)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 121, in errors
    self.full_clean()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 273, in full_clean
    self._clean_fields()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 291, in _clean_fields
    value = getattr(self, 'clean_%s' % name)()
  File "/Users/james/Sites/shared/pulls/sayit/speeches/forms.py", line 364, in clean_parent
    descendant_ids = [ d.id for d in self.instance.get_descendants ]
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 55, in __get__
    result = self.method(inst)
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 316, in get_descendants
    return self._get_descendants_by_speech()
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 319, in _get_descendants_by_speech
    dqs = self._get_descendants(include_min=True, **kwargs)
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 205, in _get_descendants
    s = s[1:]
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1456, in __getitem__
    return list(self)[k]
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1402, in __iter__
    for pos, column in enumerate(self.columns):
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1479, in columns
    self._columns = self.query.get_columns()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/sql/query.py", line 68, in get_columns
    for column_meta in self.cursor.description]
TypeError: 'NoneType' object is not iterable
-------------------- >> begin captured logging << --------------------
django.request: ERROR: Internal Server Error: /sections/add
Traceback (most recent call last):
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/base.py", line 69, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/utils/decorators.py", line 29, in _wrapper
    return bound_func(*args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/instances/views.py", line 20, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/utils/decorators.py", line 25, in bound_func
    return func(self, *args2, **kwargs2)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/instances/views.py", line 31, in dispatch
    return super(InstanceFormMixin, self).dispatch(*args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/base.py", line 87, in dispatch
    return handler(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/edit.py", line 205, in post
    return super(BaseCreateView, self).post(request, *args, **kwargs)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/views/generic/edit.py", line 170, in post
    if form.is_valid():
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 129, in is_valid
    return self.is_bound and not bool(self.errors)
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 121, in errors
    self.full_clean()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 273, in full_clean
    self._clean_fields()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/forms/forms.py", line 291, in _clean_fields
    value = getattr(self, 'clean_%s' % name)()
  File "/Users/james/Sites/shared/pulls/sayit/speeches/forms.py", line 364, in clean_parent
    descendant_ids = [ d.id for d in self.instance.get_descendants ]
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 55, in __get__
    result = self.method(inst)
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 316, in get_descendants
    return self._get_descendants_by_speech()
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 319, in _get_descendants_by_speech
    dqs = self._get_descendants(include_min=True, **kwargs)
  File "/Users/james/Sites/shared/pulls/sayit/speeches/models.py", line 205, in _get_descendants
    s = s[1:]
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1456, in __getitem__
    return list(self)[k]
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1402, in __iter__
    for pos, column in enumerate(self.columns):
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/query.py", line 1479, in columns
    self._columns = self.query.get_columns()
  File "/Users/james/.virtualenvs/sayit/lib/python2.7/site-packages/django/db/models/sql/query.py", line 68, in get_columns
    for column_meta in self.cursor.description]
TypeError: 'NoneType' object is not iterable
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: test_section_creation (speeches.tests.section_tests.SectionModelTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/james/Sites/shared/pulls/sayit/speeches/tests/section_tests.py", line 88, in test_section_creation
    self.assertEqual(children, [ 'Monday 25th March', 'Oral Answers to Questions - Silly Walks', 'Bill on Silly Walks', 'Friday 29th March', 'Fixed Easter Bill', 'New Clause 1', 'Clause 1', 'Z Clause' ])
AssertionError: Lists differ: [u'Monday 25th March', u'Oral ... != ['Monday 25th March', 'Oral An...

First differing element 5:
Clause 1
New Clause 1

- [u'Monday 25th March',
?  -

+ ['Monday 25th March',
-  u'Oral Answers to Questions - Silly Walks',
?  -

+  'Oral Answers to Questions - Silly Walks',
-  u'Bill on Silly Walks',
?  -

+  'Bill on Silly Walks',
-  u'Friday 29th March',
?  -

+  'Friday 29th March',
-  u'Fixed Easter Bill',
?  -

+  'Fixed Easter Bill',
-  u'Clause 1',
-  u'New Clause 1',
?  -

+  'New Clause 1',
+  'Clause 1',
-  u'Z Clause']
?  -

+  'Z Clause']

======================================================================
FAIL: test_add_speech_metadata_in_section (speeches.tests.speech_tests.SpeechTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/james/Sites/shared/pulls/sayit/speeches/tests/speech_tests.py", line 214, in test_add_speech_metadata_in_section
    _check_initial(self, resp, section, speakers[2], speech_data)
  File "/Users/james/Sites/shared/pulls/sayit/speeches/tests/speech_tests.py", line 152, in _check_initial_speech_data
    test.assertEqual(initial['speaker'], speaker)
AssertionError: <Speaker: Speaker 1> != <Speaker: Speaker 2>

----------------------------------------------------------------------
Ran 86 tests in 7.915s

FAILED (SKIP=3, errors=1, failures=2)
Destroying test database for alias 'default'...
```

<!---
@huboard:{"order":64.7265625,"milestone_order":303,"custom_state":""}
-->
