### PR TITLE
Update convert-to-em signature for Foundation 4.3.2

### DIFF
--- a/speeches/static/speeches/sass/_settings.scss
+++ b/speeches/static/speeches/sass/_settings.scss
@@ -25,8 +25,8 @@ $em-base: 16 !default;
 }
 
 // Converts "px" to "em" using the ($)em-base
-@function convert-to-em($value)  {
-  $value: strip-unit($value) / strip-unit($em-base) * 1em;
+@function convert-to-em($value, $base-value: $em-base)  {
+  $value: strip-unit($value) / strip-unit($base-value) * 1em;
   @if ($value == 0em) { $value: 0; } // Turn 0em into 0
   @return $value;
 }


### PR DESCRIPTION
When using the 4.3.2 gem, this avoids:

```
Line 186 of _global.scss: Function convert-to-em takes 1 argument but 2 were passed.
```

This change is compatible with 4.3.1.
