### PR TITLE
Declare charset before title

### DIFF
--- a/speeches/templates/speeches/base.html
+++ b/speeches/templates/speeches/base.html
@@ -1,8 +1,8 @@
 {% load staticfiles %}{% load url from future %}<!DOCTYPE html>
 <html>
     <head>
-        <title>{% block fulltitle %}{% block title %}{% endblock %} :: SayIt{% endblock %}</title>
         <meta charset="utf-8">
+        <title>{% block fulltitle %}{% block title %}{% endblock %} :: SayIt{% endblock %}</title>
 
         {% block extra_headers %}{% endblock %}
 


### PR DESCRIPTION
Otherwise, some browsers will try to guess the charset based on the title's encoding.
