### PR TITLE
Don't require auth middlewares if not taking advantage of instances

### DIFF
--- a/speeches/middleware.py
+++ b/speeches/middleware.py
@@ -7,6 +7,6 @@ class InstanceMiddleware:
     def process_request(self, request):
         request.instance, _ = Instance.objects.get_or_create(label='default')
         request.is_user_instance = (
-            request.user.is_authenticated() and
+            hasattr(request, 'user') and request.user.is_authenticated() and
             ( request.instance in request.user.instances.all() or request.user.is_superuser )
         )


### PR DESCRIPTION
I don't use Django admin (don't need it), so I removed that app along with the auth middlewares (I still need the auth app because the instances app depends on it). I'm not taking advantage of instances though - I just have a single default instance.

Without this PR, if those auth middlewares are missing, the speeches middleware will complain about the request not having a user attribute.
