### PR TITLE
Unhide unimportant sections which contain errors.

### DIFF
--- a/speeches/static/speeches/js/speeches.js
+++ b/speeches/static/speeches/js/speeches.js
@@ -109,7 +109,8 @@ function sayit_link_prev_next_keyboard() {
 }
 
 function setup_unimportant_sections() {
-    $('.unimportant-form-section-header').addClass('collapsed').on('click', function(){
+    $('.unimportant-form-section-header').on('click', function(){
         $(this).toggleClass('collapsed').next().toggle();
-    }).next().hide();
+    }).addClass('collapsed');
+    $('.unimportant-form-section').hide().has('.error').show().prev().removeClass('collapsed');
 }


### PR DESCRIPTION
(also remove 'collapsed' from the class of the previous div).

Fixes mysociety/sayit.mysociety.org#30.
