### PR TITLE
Don't display speaker appearance count if it's 0.

### DIFF
--- a/speeches/templates/speeches/speaker_detail.html
+++ b/speeches/templates/speeches/speaker_detail.html
@@ -35,14 +35,16 @@
         {% endif %}
       </div>
       <div class="speaker-page__stats">
-        <div class="stat">
-          <div class="stat__figure">
-            {{ section_count|intcomma }}
+        {% if section_count %}
+          <div class="stat">
+            <div class="stat__figure">
+              {{ section_count|intcomma }}
+            </div>
+            <div class="stat__descriptor">
+                {% blocktrans count c=section_count %}Appearance{% plural %}Appearances{% endblocktrans %}
+            </div>
           </div>
-          <div class="stat__descriptor">
-              {% blocktrans count c=section_count %}Appearance{% plural %}Appearances{% endblocktrans %}
-          </div>
-        </div>
+        {% endif %}
         <div class="stat">
           <div class="stat__figure">
             {{ paginator.count|intcomma }}


### PR DESCRIPTION
If the speaker appearance count is 0 and they have a positive speech
count that looks a bit odd, so let's just not display appearance count
in this situation.
