### PR TITLE
All non-section views including speeches should show speech dates.

### DIFF
--- a/speeches/templates/speeches/speech.html
+++ b/speeches/templates/speeches/speech.html
@@ -22,30 +22,28 @@
     {% if not speech.is_public %}
       <span class="label secondary radius right">{% trans "Invisible" %}</span>
     {% endif %}
-    {% if not nosection and speech.section_id %}
-    <div class="speech__breadcrumb">
-      <ul class="breadcrumbs">
-        {% for n in speech.section.get_ancestors %}
-            <li><a href="{{ n.get_absolute_url }}">{{ n.title }}</a></li>
-        {% endfor %}
-        {% if not result.object %}
-        <li class="no-content-after">
-          <span  class="breadcrumbs__date">
-            {{ speech.start_time|default:"" }}{% if speech.start_time and speech.start_date and speech.start_date != speech.end_date %},{% endif %}
-            {% if speech.start_date and speech.start_date != speech.end_date %}
-              {{ speech.start_date }}
+
+    {% if not nosection %}
+      {% if speech.section_id or not result.object %}
+        <div class="speech__breadcrumb">
+          <ul class="breadcrumbs">
+            {% if speech.section_id %}
+              {% for n in speech.section.get_ancestors %}
+                <li><a href="{{ n.get_absolute_url }}">{{ n.title }}</a></li>
+              {% endfor %}
             {% endif %}
-            {% if speech.end_time or speech.end_date %}
-              {% if speech.start_time or speech.start_date and speech.start_date != speech.end_date %} &ndash; {% endif %}
-              {{ speech.end_time|default:"" }}{% if speech.end_time and speech.end_date %},{% endif %}
-              {{ speech.end_date }}
+            {% if not result.object %}
+              <li class="no-content-after">
+                <span class="breadcrumbs__date">
+                  {% include 'speeches/speech_date_bit.html' %}
+                </span>
+              </li>
             {% endif %}
-          </span>
-        </li>
-        {% endif %}
-      </ul>
-    </div>
+          </ul>
+        </div>
+      {% endif %}
     {% endif %}
+
     <div class="speech__meta-data">
       {% if speech.speaker and not nospeaker %}
         <span class="speech__meta-data__speaker-name">
@@ -57,23 +55,22 @@
         </span>
       {% endif %}
 
-
   {% if not nospeaker %}
-    {% ifchanged %}
-    {% if speech.start_time or speech.start_date or speech.end_time or speech.end_date %}
-      <span class="speech__meta-data__date">
-        {{ speech.start_time|default:"" }}{% if speech.start_time and speech.start_date and speech.start_date != speech.end_date %},{% endif %}
-        {% if speech.start_date and speech.start_date != speech.end_date %}
-          {{ speech.start_date }}
+    {% if standalone or result.object %}
+      {% if speech.start_time or speech.start_date or speech.end_time or speech.end_date %}
+        <span class="speech__meta-data__date">
+          {% include 'speeches/speech_date_bit.html' %}
+        </span>
+      {% endif %}
+    {% else %}
+      {% ifchanged %}
+        {% if speech.start_time or speech.start_date or speech.end_time or speech.end_date %}
+          <span class="speech__meta-data__date">
+            {% include 'speeches/speech_date_bit.html' %}
+          </span>
         {% endif %}
-        {% if speech.end_time or speech.end_date %}
-        {% if speech.start_time or speech.start_date and speech.start_date != speech.end_date %} &ndash; {% endif %}
-          {{ speech.end_time|default:"" }}{% if speech.end_time and speech.end_date %},{% endif %}
-          {{ speech.end_date }}
-        {% endif %}
-      </span>
+      {% endifchanged %}
     {% endif %}
-    {% endifchanged %}
   {% endif %}
 
   {% for tag in speech.tags.all %}

--- a/speeches/templates/speeches/speech_date_bit.html
+++ b/speeches/templates/speeches/speech_date_bit.html
@@ -1,0 +1,9 @@
+{{ speech.start_time|default:"" }}{% if speech.start_time and speech.start_date and speech.start_date != speech.end_date %},{% endif %}
+{% if speech.start_date and speech.start_date != speech.end_date %}
+  {{ speech.start_date }}
+{% endif %}
+{% if speech.end_time or speech.end_date %}
+{% if speech.start_time or speech.start_date and speech.start_date != speech.end_date %} &ndash; {% endif %}
+  {{ speech.end_time|default:"" }}{% if speech.end_time and speech.end_date %},{% endif %}
+  {{ speech.end_date }}
+{% endif %}

--- a/speeches/tests/search_tests.py
+++ b/speeches/tests/search_tests.py
@@ -1,3 +1,6 @@
+import datetime
+import re
+
 from django.core.management import call_command
 from haystack.query import SearchQuerySet
 
@@ -22,10 +25,23 @@ class SearchTests(InstanceTestCase):
     def test_search_results(self):
         s1 = self.instance.speaker_set.create(name='Speaker 1')
         s2 = self.instance.speaker_set.create(name='Speaker 2')
-        self.instance.speech_set.create(speaker=s1, text='Some text by speaker 1')
-        self.instance.speech_set.create(speaker=s1, text='Some more text by speaker 1')
+        self.instance.speech_set.create(
+            speaker=s1,
+            text='Some text by speaker 1',
+            start_date=datetime.date(2014, 9, 17),
+            )
+        self.instance.speech_set.create(
+            speaker=s1,
+            text='Some more text by speaker 1',
+            start_date=datetime.date(2014, 9, 17),
+            )
         self.instance.speech_set.create(speaker=s2, text='Some text by speaker 2')
         call_command('rebuild_index', verbosity=0, interactive=False)
 
         resp = self.client.get('/search/?q=more')
         self.assertContains(resp, 'Some <em>more</em> text by speaker 1')
+
+        # Check that a search which returns more than one speech on the same
+        # date displays a date for each.
+        resp = self.client.get('/search/?q="speaker 1"')
+        assert len(re.findall(r'<span class="speech__meta-data__date">\s*17 Sep 2014\s*</span>', resp.content.decode())) == 2


### PR DESCRIPTION
In a section it makes sense to not show a speech date if it matches
the date of the speech before, but when viewing a speaker or a set
of search results, the speeches are not an ordered group, so we should
show the date for every speech.
