### PR TITLE
Remove erroneous closing bracket

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ of transcripts, including:
 Another is `OpenHouse Nova Scotia <http://www.openhousens.ca>`_, providing an
 unofficial record of the proceedings of the Nova Scotia House of Assembly.
 
-SayIt is a `Poplus component <http://poplus.org)>`_
+SayIt is a `Poplus component <http://poplus.org>`_
 by `mySociety <http://www.mysociety.org/>`_.
 
 Get involved


### PR DESCRIPTION
With the closing bracket in the URL (which I assume is erroneous), browsers
still see the link as an href (as the RST is parsed in to HTML by GitHub),
but the page won't load because the closing bracket is erroneous.

Fixes this.
