### PR TITLE
Clobbering refinement in AkomaNtoso import

### DIFF
--- a/speeches/fixtures/test_inputs/test_clobber.xml
+++ b/speeches/fixtures/test_inputs/test_clobber.xml
@@ -9,6 +9,12 @@
             <speech>
                 <p>Howdy</p>
             </speech>
+            <debateSection>
+                <heading>Conclusions</heading>
+                <speech>
+                    <p>Bye</p>
+                </speech>
+            </debateSection>
         </debateBody>
     </debate>
 </akomaNtoso>

--- a/speeches/fixtures/test_inputs/test_empty_title.xml
+++ b/speeches/fixtures/test_inputs/test_empty_title.xml
@@ -11,6 +11,17 @@
                     <p>Hello</p>
                 </speech>
             </debateSection>
+            <debateSection>
+                <speech>
+                    <p>Howdy</p>
+                </speech>
+            </debateSection>
+            <debateSection>
+                <heading>Conclusions</heading>
+                <speech>
+                    <p>Bye</p>
+                </speech>
+            </debateSection>
         </debateBody>
     </debate>
 </akomaNtoso>

--- a/speeches/management/import_commands.py
+++ b/speeches/management/import_commands.py
@@ -27,12 +27,15 @@ class ImportCommand(BaseCommand):
             '--dump-users', action='store', default='',
             help='dump a json list to <file> (only valid with --dir for now)'),
         make_option(
-            '--clobber-existing', action='store_true', dest='clobber',
-            help='Whether to replace top-level sections with the same heading'),
+            '--clobber-existing', action='store_const', const='replace', dest='clobber',
+            help='Whether to replace sections with the same heading'),
         make_option(
-            '--skip-existing', action='store_false', dest='clobber',
-            help='Whether to skip top-level sections with the same heading'),
-    )
+            '--skip-existing', action='store_const', const='skip', dest='clobber',
+            help='Whether to skip sections with the same heading'),
+        make_option(
+            '--merge-existing', action='store_const', const='merge', dest='clobber',
+            help='Whether to merge sections with the same heading'),
+     )
 
     def handle(self, *args, **options):
         verbosity = int(options['verbosity'])

--- a/speeches/management/import_commands.py
+++ b/speeches/management/import_commands.py
@@ -55,7 +55,7 @@ class ImportCommand(BaseCommand):
                 if section and section.id:
                     logger.info("Imported section %d\n\n" % section.id)
         elif options['dir']:
-            files = self.document_list(options)
+            files = sorted(self.document_list(options))
 
             if len(files):
                 imports = [self.import_document(f, **options) for f in files]

--- a/speeches/tests/importer_tests.py
+++ b/speeches/tests/importer_tests.py
@@ -20,6 +20,14 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
         super(AkomaNtosoImportTestCase, self).setUp()
         self.importer = ImportAkomaNtoso(instance=self.instance, commit=True)
 
+    def _list_sections(self):
+        # Make mapping {section name: list of its speeches' texts}
+        sections = {section.id: [] for section in Section.objects.all()}
+        for speech in Speech.objects.all():
+            if speech.section_id:
+                sections[speech.section_id].append(speech.text)
+        return {section.title: sections[section.id] for section in Section.objects.all()}
+
     def test_import_sample_file(self):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/Debate_Bungeni_1995-10-31.xml')
@@ -49,99 +57,129 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
     def test_already_imported(self):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/test_xpath.xml')
+        self.assertEqual(
+            self._list_sections(),
+            {'This is the title': ['<p>Hello</p>']}
+            )
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.text for x in Speech.objects.all()],
-            ['<p>Hello</p>']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Hello</p>']}
+            )
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.text for x in Speech.objects.all()],
-            ['<p>Hello</p>', '<p>Howdy</p>']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Hello</p>', '<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.text for x in Speech.objects.all()],
-            ['<p>Howdy</p>']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True).import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.text for x in Speech.objects.all()],
-            ['<p>Howdy</p>', '<p>Howdy</p>']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>'],
+             'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
     def test_not_already_imported(self):
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
-            'speeches/fixtures/test_inputs/test_xpath.xml')
+            'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['This is the title']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
         Section.objects.all().delete()
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
-            'speeches/fixtures/test_inputs/test_xpath.xml')
+            'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['This is the title']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
         Section.objects.all().delete()
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
-            'speeches/fixtures/test_inputs/test_xpath.xml')
+            'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['This is the title']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
         Section.objects.all().delete()
 
         ImportAkomaNtoso(instance=self.instance, commit=True).import_document(
-            'speeches/fixtures/test_inputs/test_xpath.xml')
+            'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['This is the title']
-        )
+            self._list_sections(),
+            {'This is the title': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
         Section.objects.all().delete()
 
     def test_empty_title(self):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
+        self.assertEqual(
+            self._list_sections(),
+            {'': ['<p>Hello</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['']
-        )
+            self._list_sections(),
+            {'': ['<p>Hello</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['']
-        )
+            self._list_sections(),
+            {'': ['<p>Hello</p>', '<p>Hello</p>', '<p>Howdy</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>', '<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['']
-        )
+            self._list_sections(),
+            {'': ['<p>Hello</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
         ImportAkomaNtoso(instance=self.instance, commit=True).import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
-            [x.title for x in Section.objects.all()],
-            ['', '']
-        )
+            self._list_sections(),
+            {'': ['<p>Hello</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>'],
+             '': ['<p>Hello</p>'],
+             '': ['<p>Howdy</p>'],
+             'Conclusions': ['<p>Bye</p>']
+            })
 
     def test_xpath_preface_elements(self):
         self.importer.import_document(

--- a/speeches/tests/importer_tests.py
+++ b/speeches/tests/importer_tests.py
@@ -50,14 +50,21 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/test_xpath.xml')
 
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=False).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
             [x.text for x in Speech.objects.all()],
             ['<p>Hello</p>']
         )
 
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=True).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
+            'speeches/fixtures/test_inputs/test_clobber.xml')
+        self.assertEqual(
+            [x.text for x in Speech.objects.all()],
+            ['<p>Hello</p>', '<p>Howdy</p>']
+        )
+
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
             'speeches/fixtures/test_inputs/test_clobber.xml')
         self.assertEqual(
             [x.text for x in Speech.objects.all()],
@@ -72,7 +79,7 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
         )
 
     def test_not_already_imported(self):
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=False).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
             'speeches/fixtures/test_inputs/test_xpath.xml')
         self.assertEqual(
             [x.title for x in Section.objects.all()],
@@ -80,7 +87,15 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
         )
         Section.objects.all().delete()
 
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=True).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
+            'speeches/fixtures/test_inputs/test_xpath.xml')
+        self.assertEqual(
+            [x.title for x in Section.objects.all()],
+            ['This is the title']
+        )
+        Section.objects.all().delete()
+
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
             'speeches/fixtures/test_inputs/test_xpath.xml')
         self.assertEqual(
             [x.title for x in Section.objects.all()],
@@ -100,25 +115,32 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
 
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=False).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='skip').import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
             [x.title for x in Section.objects.all()],
-            ['', '']
+            ['']
         )
 
-        ImportAkomaNtoso(instance=self.instance, commit=True, clobber=True).import_document(
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='merge').import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
             [x.title for x in Section.objects.all()],
-            ['', '', '']
+            ['']
+        )
+
+        ImportAkomaNtoso(instance=self.instance, commit=True, clobber='replace').import_document(
+            'speeches/fixtures/test_inputs/test_empty_title.xml')
+        self.assertEqual(
+            [x.title for x in Section.objects.all()],
+            ['']
         )
 
         ImportAkomaNtoso(instance=self.instance, commit=True).import_document(
             'speeches/fixtures/test_inputs/test_empty_title.xml')
         self.assertEqual(
             [x.title for x in Section.objects.all()],
-            ['', '', '', '']
+            ['', '']
         )
 
     def test_xpath_preface_elements(self):


### PR DESCRIPTION
We use a three-level section hierarchy for parliamentary debates: electoral term - session - sitting. There is one AN file per sitting and the files share up to two outer level sections. To import a file into an existing hierarchy and still have an opportunity to replace existing sections I propose the following two changes in AkomaNtoso import.

Clobbering works on all levels of section hierarchy now, not on the top-level section only.

There are three options for clobbering of sections with the same heading:

* `skip` to skip import of a section that already exists,
* `replace` to delete existing section and replace it with the imported one,
* `merge` to append content of the imported section to the existing one.

It might be better also to join respective command-line options into something like `--clobbering` with three allowed values `skip`, `replace` and `merge`. I just added third separate option `--merge-existing` to the existing two in sake of backwards compatibility.


<!---
@huboard:{"order":68.2265625,"milestone_order":423,"custom_state":""}
-->
