### PR TITLE
Fix flake8 pre-commit hook.

### DIFF
--- a/conf/hook-pre-commit
+++ b/conf/hook-pre-commit
@@ -38,4 +38,14 @@ command -v flake8 >/dev/null 2>&1 || {
   exit 1
 }
 
-flake8 && echo -e "\033[32mOK \033[0mflake8" || echo -e "\033[31mFAILED \033[0mflake8"
+flake8
+exit_code=$?
+
+if [ $exit_code -eq 0 ]
+then
+    echo -e "\033[32mOK \033[0mflake8"
+else
+    echo -e "\033[31mFAILED \033[0mflake8"
+fi
+
+exit $exit_code


### PR DESCRIPTION
The pre-commit hook was merrily exiting with a 0 on non-pep8
compliant code because it was returning the exit status of the echo.