### PR TITLE
Fix AN import of empty docDate or link.

### DIFF
--- a/speeches/fixtures/test_inputs/test_empty_docDate.xml
+++ b/speeches/fixtures/test_inputs/test_empty_docDate.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<akomaNtoso>
+    <debate>
+        <preface>
+            <docDate date="2012-03-07"/>
+            <docTitle>Title</docTitle>
+            <link href="http://example.org"/>
+        </preface>
+        <debateBody>
+        </debateBody>
+    </debate>
+</akomaNtoso>

--- a/speeches/importers/import_akomantoso.py
+++ b/speeches/importers/import_akomantoso.py
@@ -58,7 +58,7 @@ class ImportAkomaNtoso(ImporterBase):
             self.speakers[id] = speaker
 
         docDate = self.get_preface_tag(debate, 'docDate')
-        if docDate:
+        if docDate is not None:
             self.start_date = dateutil.parse(docDate.get('date'))
 
         docTitle = self.get_preface_tag(debate, 'docTitle')
@@ -77,8 +77,8 @@ class ImportAkomaNtoso(ImporterBase):
         if session:
             session = session.text
 
-        source_url = self.get_preface_tag(debate, 'link') or ''
-        if source_url:
+        source_url = self.get_preface_tag(debate, 'link')
+        if source_url is not None:
             source_url = source_url.get('href')
 
         self.imported_section_ids = set()

--- a/speeches/tests/importer_tests.py
+++ b/speeches/tests/importer_tests.py
@@ -187,6 +187,14 @@ class AkomaNtosoImportTestCase(InstanceTestCase):
              'Conclusions': ['<p>Bye</p>'],
              })
 
+    def test_empty_docDate(self):
+        self.importer.import_document(
+            'speeches/fixtures/test_inputs/test_empty_docDate.xml')
+        self.assertEqual(
+            [(x.start_date, x.title, x.source_url) for x in Section.objects.all()],
+            [(datetime.date(2012, 3, 7), 'Title', 'http://example.org')]
+        )
+
     def test_xpath_preface_elements(self):
         self.importer.import_document(
             'speeches/fixtures/test_inputs/test_xpath.xml')


### PR DESCRIPTION
If the element was empty, then the attribute was not imported.
Thanks to Yuanhsiang Cheng for reporting.