### PR TITLE
Add a migration of Speaker options Django expects to exist

### DIFF
--- a/speeches/migrations/0002_remove_ordering_from_speaker_options.py
+++ b/speeches/migrations/0002_remove_ordering_from_speaker_options.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('speeches', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='speaker',
+            options={'verbose_name': 'speaker', 'verbose_name_plural': 'speakers'},
+        ),
+    ]


### PR DESCRIPTION
The ordering option was removed from Speaker's Meta class in
9d1a53b47f051fc0 - Django expect a corresponding migration to
be present, or it complains that you need to run makemigrations.