### PR TITLE
Various code updates for modern Django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ sudo: false
 language: python
 python: 3.5
 
-services:
-  - elasticsearch
-
 matrix:
   include:
     - python: 2.7
@@ -17,6 +14,9 @@ matrix:
 env:
   global:
     - CFLAGS="-O0"
+    - ES_VERSION=1.4.0
+    - GECKODRIVER=0.20.1
+    - ES_TOX="elasticsearch==$ES_VERSION"
   matrix:
     - TOXENV=flake8
     - TOXENV=py35-1.11
@@ -24,7 +24,6 @@ env:
     - TOXENV=py35-2.2
 
 addons:
-  firefox: latest
   postgresql: 9.6
   apt:
     packages:
@@ -32,13 +31,16 @@ addons:
       - xvfb
 
 before_install:
-  - wget https://github.com/mozilla/geckodriver/releases/download/v0.17.0/geckodriver-v0.17.0-linux64.tar.gz
+  - wget https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER/geckodriver-v$GECKODRIVER-linux64.tar.gz
   - mkdir geckodriver
-  - tar -xzf geckodriver-v0.17.0-linux64.tar.gz -C geckodriver
+  - tar -xzf geckodriver-v$GECKODRIVER-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 
 install:
   - pip install tox
+  - wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.tar.gz
+  - tar -xzf elasticsearch-$ES_VERSION.tar.gz
+  - ./elasticsearch-$ES_VERSION/bin/elasticsearch &
 
 before_script:
   - psql -c 'create database "sayit-example-project";' -U postgres
@@ -46,4 +48,5 @@ before_script:
   - 'if [ $TOXENV != "flake8" ]; then sh -e /etc/init.d/xvfb start; fi'
 
 script:
+  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,31 @@ notifications:
 sudo: false
 
 language: python
+python: 3.5
 
 services:
   - elasticsearch
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-1.11
 
 env:
   global:
     - CFLAGS="-O0"
   matrix:
     - TOXENV=flake8
-    - TOXENV=py27-1.8
-    - TOXENV=py27-1.10
-    - TOXENV=py27-1.11
-    - TOXENV=py34-1.8
-    - TOXENV=py34-1.10
-    - TOXENV=py34-1.11
+    - TOXENV=py35-1.11
+    - TOXENV=py35-2.1
+    - TOXENV=py35-2.2
 
 addons:
   firefox: latest
+  postgresql: 9.6
   apt:
     packages:
-      - ffmpeg
-      - libavcodec-extra-53
+      - libav-tools
       - xvfb
 
 before_install:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+v2.0, 2019-04-10
+    * Django 2 support.
+    * Drop support for Django before 1.11.
+    * Test fixes for changes on Travis.
+    * Add config for ffmpeg binary name.
+
 v1.5, 2017-06-16
     * Django 1.10 and 1.11 support.
 

--- a/example_project/settings/base.py
+++ b/example_project/settings/base.py
@@ -100,7 +100,9 @@ TEMPLATES = [
         },
     },
 ]
-MIDDLEWARE_CLASSES = [
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/example_project/settings/base.py
+++ b/example_project/settings/base.py
@@ -269,6 +269,8 @@ HAYSTACK_CONNECTIONS = {
 
 HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
+FFMPEG = 'avconv'
+
 # Allow local changes of settings
 try:
     with open(SETTINGS_DIR + '/local.py') as f:

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -23,7 +23,7 @@ if 'test' in sys.argv:
         url(r'^%s(?P<path>.*)$' % static_url, static_views.serve, {
             'insecure': True,
         }),
-        url('^(?P<path>favicon\.ico)$', static_views.serve, {
+        url(r'^(?P<path>favicon\.ico)$', static_views.serve, {
             'insecure': True,
         }),
     ]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -30,10 +30,10 @@ if 'test' in sys.argv:
 
 urlpatterns += [
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 
-    url(r'^accounts/login/$', auth_views.login, name='login'),
-    url(r'^accounts/logout/$', auth_views.logout, {'next_page': '/'}, name='logout'),
+    url(r'^accounts/login/$', auth_views.LoginView.as_view(), name='login'),
+    url(r'^accounts/logout/$', auth_views.LogoutView.as_view(), {'next_page': '/'}, name='logout'),
 
-    url(r'^', include('speeches.urls', app_name='speeches', namespace='speeches')),
+    url(r'^', include('speeches.urls', namespace='speeches')),
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude=build,.tox,.venvs,south_migrations,migrations,example_project/settings/local.py
-ignore=E123,F405
+ignore=E123,F405,E722,W504
 max-line-length=119

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ else:
     ]
 
 if os.environ.get('TOX'):
-    django = 'Django >= 1.8.5'
+    django = 'Django >= 1.11'
 else:
-    django = 'Django >= 1.8.5, < 2.0'
+    django = 'Django >= 1.11, < 2.0'
 
 setup(
     name="django-sayit",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ else:
 if os.environ.get('TOX'):
     django = 'Django >= 1.11'
 else:
-    django = 'Django >= 1.11, < 2.0'
+    django = 'Django >= 1.11, < 3.0'
 
 setup(
     name="django-sayit",
@@ -42,14 +42,14 @@ setup(
         'six >= 1.4.1',
         django,
         'lxml',
-        'mysociety-Django-Select2 == 4.3.2.1',
+        'mysociety-Django-Select2 == 4.3.2.2',
         'audioread >= 1.0.1',
         'elasticsearch >= 0.4',
-        'django-haystack >= 2.5, < 2.6',
+        'django-haystack >= 2.8, < 2.9',
         'django-bleach >= 0.5.2',
-        'mysociety-django-popolo >= 0.0.5',
-        'mysociety-django-sluggable >= 0.2.7',
-        'django-subdomain-instances >= 2.0',
+        'mysociety-django-popolo >= 0.1.0',
+        'mysociety-django-sluggable >= 0.6.1.1',
+        'django-subdomain-instances >= 3.0.2',
         'easy-thumbnails >= 2.4.1',
         'unicode-slugify == 0.1.1',
     ] + ssl,

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'audioread >= 1.0.1',
         'elasticsearch >= 0.4',
         'django-haystack >= 2.5, < 2.6',
-        'django-bleach >= 0.3.0',
+        'django-bleach >= 0.5.2',
         'mysociety-django-popolo >= 0.0.5',
         'mysociety-django-sluggable >= 0.2.7',
         'django-subdomain-instances >= 2.0',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ else:
 
 setup(
     name="django-sayit",
-    version='1.5',
+    version='2.0',
     description='A data store for speeches and transcripts to make them searchable and pretty.',
     long_description=read_file('README.rst'),
     author='mySociety',

--- a/speeches/colour.py
+++ b/speeches/colour.py
@@ -16,8 +16,8 @@ def relative_luminance(h):
     r = rel_calc(h[0:2])
     g = rel_calc(h[2:4])
     b = rel_calc(h[4:6])
-    l = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    return l
+    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    return luminance
 
 
 def contrast_ratio(l1, l2):

--- a/speeches/fields.py
+++ b/speeches/fields.py
@@ -1,5 +1,4 @@
 import datetime
-from itertools import chain
 
 from django import forms
 from django.core import validators
@@ -44,7 +43,7 @@ class FromStartIntegerField(forms.IntegerField):
 # database.
 
 class TagWidget(forms.SelectMultiple):
-    def render(self, name, value, attrs=None, choices=()):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = []
         final_attrs = self.build_attrs(attrs, type='text', name=name)
@@ -52,7 +51,7 @@ class TagWidget(forms.SelectMultiple):
         value = set(force_text(v) for v in value)
         selected = []
         all_tags = []
-        for option_value, option_label in chain(self.choices, choices):
+        for option_value, option_label in self.choices:
             option_value = force_text(option_value)
             option_label = force_text(option_label)
             if option_value in value:

--- a/speeches/forms.py
+++ b/speeches/forms.py
@@ -109,11 +109,11 @@ class Select2Widget(AutoHeavySelect2Widget):
             else:
                 return data.getlist(name)
 
-    def render(self, name, value, attrs=None, choices=()):
+    def render(self, name, value, attrs=None, renderer=None):
         """Because of the above; if we are given a list here, we don't want it."""
         if isinstance(value, list):
             value = value[0] if len(value) else None
-        return super(Select2Widget, self).render(name, value, attrs, choices)
+        return super(Select2Widget, self).render(name, value, attrs, renderer)
 
 
 class Select2CreateWidget(Select2Widget):
@@ -228,7 +228,7 @@ class NonCreateSectionField(NonCreateAutoModelSelect2Field):
 
 
 class SpeechTextFieldWidget(forms.Textarea):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         # These first two steps are also done in the superclass, but it's
         # safe to repeat them here to get value to the right state.
         if value is None:
@@ -237,7 +237,7 @@ class SpeechTextFieldWidget(forms.Textarea):
         value = re.sub(r'<br ?/?>', '<br />\n', value)
         value = remove_p_and_br(value)
 
-        return super(SpeechTextFieldWidget, self).render(name, value, attrs)
+        return super(SpeechTextFieldWidget, self).render(name, value, attrs, renderer)
 
 
 class SpeechTextField(StripWhitespaceField):
@@ -324,7 +324,7 @@ class SpeechForm(forms.ModelForm, CleanAudioMixin):
         # <br /> and get rid of the ones round the outside.
         if 'text' in cleaned_data and not cleaned_data.get('speaker'):
             text = cleaned_data['text']
-            text = re.sub(r'</p>\n\n<p>', '<br />\n', text)
+            text = re.sub(r'</p>\n\n<p>', '<br>\n', text)
             text = re.sub(r'</?p>', '', text)
             cleaned_data['text'] = text
 

--- a/speeches/middleware.py
+++ b/speeches/middleware.py
@@ -1,13 +1,16 @@
 from instances.models import Instance
 
 
-class InstanceMiddleware:
+def InstanceMiddleware(get_response):
     """This middleware sets request.instance to the default Instance for all
     requests. This can be changed/overridden if you use SayIt in a way that
     uses multiple instances."""
-    def process_request(self, request):
+    def middleware(request):
         request.instance, _ = Instance.objects.get_or_create(label='default')
         request.is_user_instance = (
-            hasattr(request, 'user') and request.user.is_authenticated() and
+            hasattr(request, 'user') and request.user.is_authenticated and
             (request.instance in request.user.instances.all() or request.user.is_superuser)
         )
+        return get_response(request)
+
+    return middleware

--- a/speeches/migrations/0001_initial.py
+++ b/speeches/migrations/0001_initial.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                 ('audio', models.FileField(max_length=255, upload_to='recordings/%Y-%m-%d/')),
                 ('start_datetime', models.DateTimeField(help_text='Datetime of first timestamp associated with recording', null=True, blank=True)),
                 ('audio_duration', models.IntegerField(help_text='Duration of recording, in seconds', blank=True, default=0)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -40,8 +40,8 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('timestamp', models.DateTimeField(db_index=True)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
-                ('recording', models.ForeignKey(related_name='timestamps', to='speeches.Recording', default=0)),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
+                ('recording', models.ForeignKey(related_name='timestamps', to='speeches.Recording', default=0, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('timestamp',),
@@ -65,8 +65,8 @@ class Migration(migrations.Migration):
                 ('session', models.TextField(help_text='Legislative session', verbose_name='session', blank=True)),
                 ('slug', sluggable.fields.SluggableField(verbose_name='slug')),
                 ('source_url', models.TextField(verbose_name='source URL', blank=True)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
-                ('parent', models.ForeignKey(related_name='children', to='speeches.Section', null=True, blank=True, verbose_name='parent')),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
+                ('parent', models.ForeignKey(related_name='children', to='speeches.Section', null=True, blank=True, verbose_name='parent', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('id',),
@@ -83,7 +83,7 @@ class Migration(migrations.Migration):
                 ('slug', models.CharField(max_length=255, verbose_name='URL', db_index=True)),
                 ('redirect', models.BooleanField(default=False, verbose_name='Redirection')),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -93,10 +93,10 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Speaker',
             fields=[
-                ('person_ptr', models.OneToOneField(to='popolo.Person', auto_created=True, parent_link=True, serialize=False, primary_key=True)),
+                ('person_ptr', models.OneToOneField(to='popolo.Person', auto_created=True, parent_link=True, serialize=False, primary_key=True, on_delete=models.CASCADE)),
                 ('slug', sluggable.fields.SluggableField(verbose_name='slug')),
                 ('image_cache', easy_thumbnails.fields.ThumbnailerImageField(help_text='If image is set, a local copy will be stored here.', null=True, upload_to=speeches.models.upload_to, verbose_name='image_cache', blank=True)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('name',),
@@ -127,7 +127,7 @@ class Migration(migrations.Migration):
                 ('public', models.BooleanField(help_text='Is this speech public?', verbose_name='public', default=True)),
                 ('source_url', models.TextField(verbose_name='source URL', blank=True)),
                 ('celery_task_id', models.CharField(null=True, max_length=256, verbose_name='celery task ID', blank=True)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
                 ('section', models.ForeignKey(to='speeches.Section', help_text='The section that this speech is contained in', null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL, verbose_name='Section')),
                 ('speaker', models.ForeignKey(to='speeches.Speaker', help_text='Who gave this speech?', null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL, verbose_name='speaker')),
             ],
@@ -145,7 +145,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('name', models.CharField(unique=True, max_length=100)),
-                ('instance', models.ForeignKey(to='instances.Instance')),
+                ('instance', models.ForeignKey(to='instances.Instance', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name': 'tag',

--- a/speeches/migrations/0002_auto_20151112_2003.py
+++ b/speeches/migrations/0002_auto_20151112_2003.py
@@ -18,27 +18,27 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='recording',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='recordingtimestamp',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='section',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='speaker',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='speech',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
         migrations.AlterField(
             model_name='speech',
@@ -48,6 +48,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='tag',
             name='instance',
-            field=models.ForeignKey(verbose_name='instance', to='instances.Instance'),
+            field=models.ForeignKey(verbose_name='instance', to='instances.Instance', on_delete=models.CASCADE),
         ),
     ]

--- a/speeches/templatetags/speech_utils.py
+++ b/speeches/templatetags/speech_utils.py
@@ -4,7 +4,7 @@ from django.utils.html import linebreaks
 from django.utils.safestring import mark_safe, SafeData
 
 import bleach
-from django_bleach.templatetags.bleach_tags import bleach_args
+from django_bleach.utils import get_bleach_default_options
 
 register = template.Library()
 
@@ -28,6 +28,7 @@ def striptags_highlight(value):
 def bleach_value(value):
     """Same as django_bleach, but convert the <br> we get back to valid XML,
     for the AN export."""
+    bleach_args = get_bleach_default_options()
     bleached_value = bleach.clean(value, **bleach_args)
     bleached_value = bleached_value.replace('<br>', '<br/>')
     return mark_safe(bleached_value)

--- a/speeches/tests/opengraph_tests.py
+++ b/speeches/tests/opengraph_tests.py
@@ -139,13 +139,13 @@ class OpenGraphTests(OverrideMediaRootMixin, InstanceTestCase):
 
         self.assert_opengraph_matches(
             self.client.get('/speech/%s' % self.speech_long_html_description.id),
-            {'title': u'\u201cBut I must explain to you how ...\u201d :: SayIt',
+            {'title': re.compile(u'\u201cBut I must explain to you how (...|\u2026)\u201d :: SayIt'),
              'url': 'http://testing.example.org:8000/speech/%s' % self.speech_long_html_description.id,
              'site_name': 'SayIt',
-             'description': (
+             'description': re.compile(
                  'But I must explain to you how all this mistaken idea of '
                  'denouncing pleasure and praising pain was born and I will '
-                 'give you a complete account of the system, ...'),
+                 u'give you a complete account of the system, (...|\u2026)'),
              'type': 'website',
              'image': re.compile('http://testing.example.org:8000/uploads/speakers/default/image.*.jpg'),
              }

--- a/speeches/tests/speaker_tests.py
+++ b/speeches/tests/speaker_tests.py
@@ -170,7 +170,7 @@ class SpeakerTests(OverrideMediaRootMixin, InstanceTestCase):
         assertRegex(
             self,
             smart_text(s2.image_cache),
-            u'^speakers/default/image\u1f60%s_.{7}\.jpg$' % sixtyfive,
+            u'^speakers/default/image\u1f60%s_.{7}\\.jpg$' % sixtyfive,
             )
 
     def test_add_speaker_with_whitespace(self):

--- a/speeches/tests/speech_tests.py
+++ b/speeches/tests/speech_tests.py
@@ -589,7 +589,7 @@ class SpeechViewTests(InstanceTestCase):
         )
 
         resp = self.client.get('/section/%d' % section.id)
-        self.assertRegexpMatches(resp.content.decode(), '>\s+1 Jan 2000\s+&ndash;\s+2 Jan 2000\s+<')
+        self.assertRegexpMatches(resp.content.decode(), r'>\s+1 Jan 2000\s+&ndash;\s+2 Jan 2000\s+<')
 
     def test_speech_page_has_buttons_to_edit(self):
         # Add a section

--- a/speeches/tests/speech_tests.py
+++ b/speeches/tests/speech_tests.py
@@ -29,6 +29,10 @@ class SpeechFormTests(InstanceTestCase):
         if(os.path.exists(speeches_folder)):
             shutil.rmtree(speeches_folder)
 
+    def assertEqualWithOrWithoutSlash(self, a, b):
+        bb = b.replace('<br />', '<br>')
+        self.assertIn(a, [b, bb])
+
     def test_add_speech_page_exists(self):
         # Test that the page exists and has the right title
         resp = self.client.get('/speech/add')
@@ -278,7 +282,7 @@ class SpeechFormTests(InstanceTestCase):
 
         orig_text = 'This is a Steve speech\nAfter break\n\nNew paragraph'
         with_speaker_text = '<p>This is a Steve speech<br />After break</p>\n\n<p>New paragraph</p>'
-        no_speaker_text = 'This is a Steve speech<br />After break<br />\nNew paragraph'
+        no_speaker_text = 'This is a Steve speech<br />After break<br>\nNew paragraph'
 
         resp = self.client.post('/speech/add', {
             'text': orig_text,
@@ -286,7 +290,7 @@ class SpeechFormTests(InstanceTestCase):
         })
 
         speech = Speech.objects.get(speaker_id=speaker.id)
-        self.assertEqual(speech.text, with_speaker_text)
+        self.assertEqualWithOrWithoutSlash(speech.text, with_speaker_text)
         self.assertEqual(speech.type, 'speech')
 
         resp = self.client.get('/speech/{}/edit'.format(speech.id))
@@ -298,7 +302,7 @@ class SpeechFormTests(InstanceTestCase):
             )
 
         speech = Speech.objects.get(id=speech.id)
-        self.assertEqual(speech.text, no_speaker_text)
+        self.assertEqualWithOrWithoutSlash(speech.text, no_speaker_text)
         self.assertEqual(speech.type, 'narrative')
 
         resp = self.client.get('/speech/{}/edit'.format(speech.id))
@@ -310,7 +314,7 @@ class SpeechFormTests(InstanceTestCase):
             )
 
         speech = Speech.objects.get(speaker_id=speaker.id)
-        self.assertEqual(speech.text, with_speaker_text)
+        self.assertEqualWithOrWithoutSlash(speech.text, with_speaker_text)
         self.assertEqual(speech.type, 'speech')
 
     def test_add_speech_with_audio(self):
@@ -358,9 +362,9 @@ class SpeechFormTests(InstanceTestCase):
         text = "First line.\nAfter break.\n\nAfter another break."
         self.client.post('/speech/add', {'text': text})
         speech = Speech.objects.order_by('-id')[0]
-        self.assertEqual(
+        self.assertEqualWithOrWithoutSlash(
             speech.text,
-            'First line.<br />After break.<br />\nAfter another break.'
+            'First line.<br />After break.<br>\nAfter another break.'
             )
 
         resp = self.client.get("/speech/%d/edit" % speech.id)
@@ -374,7 +378,7 @@ class SpeechFormTests(InstanceTestCase):
             {'text': text, 'speaker': speaker.id},
             )
         speech = Speech.objects.order_by('-id')[0]
-        self.assertEqual(
+        self.assertEqualWithOrWithoutSlash(
             speech.text,
             '<p>First line.<br />After break.</p>\n\n<p>New paragraph.</p>'
             )
@@ -396,7 +400,7 @@ class SpeechFormTests(InstanceTestCase):
         speech = Speech.objects.order_by('-id')[0]
         self.assertEqual(
             speech.text,
-            "Test<br />string<br />\nSecond paragraph<br />\nThird paragraph<br />\nFourth paragraph"
+            "Test<br />string<br>\nSecond paragraph<br>\nThird paragraph<br>\nFourth paragraph"
             )
 
     def test_add_speech_with_html_and_speaker(self):

--- a/speeches/urls.py
+++ b/speeches/urls.py
@@ -24,6 +24,7 @@ try:
 except:
     v01_api = None
 
+app_name = 'speeches'
 urlpatterns = [
     url(r'^$', InstanceView.as_view(), name='home'),
 

--- a/speeches/utils/audio.py
+++ b/speeches/utils/audio.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 import calendar
 import audioread.ffdec
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,7 @@ class AudioHelper(object):
 
     def _build_ffmpeg_options(self, in_filename):
         return [
-            'ffmpeg',
+            settings.FFMPEG,
             # Tell ffmpeg to shut up
             '-loglevel',
             '0',

--- a/speeches/views.py
+++ b/speeches/views.py
@@ -3,7 +3,7 @@ import json
 from six import string_types
 
 from django.http import HttpResponse, HttpResponseRedirect
-from django.core.urlresolvers import reverse, reverse_lazy, resolve
+from django.urls import reverse, reverse_lazy, resolve
 from django.core import serializers
 from django.contrib import messages
 from django.forms import Form

--- a/speeches/widgets.py
+++ b/speeches/widgets.py
@@ -15,7 +15,7 @@ class AudioFileInput(ClearableFileInput):
         u'%(clear_checkbox_label)s</label>'
 
     # Overridden whole function to provide nicer input button
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         substitutions = {
             'initial_text': self.initial_text,
             'input_text': self.input_text,
@@ -25,7 +25,7 @@ class AudioFileInput(ClearableFileInput):
             'pretty_input_end': self.pretty_input_end,
         }
         template = u'%(pretty_input_start)s%(input)s%(pretty_input_end)s'
-        substitutions['input'] = super(ClearableFileInput, self).render(name, value, attrs)
+        substitutions['input'] = super(ClearableFileInput, self).render(name, value, attrs, renderer)
 
         if value and hasattr(value, "url"):
             template = self.template_with_initial
@@ -36,7 +36,8 @@ class AudioFileInput(ClearableFileInput):
                 checkbox_id = self.clear_checkbox_id(checkbox_name)
                 substitutions['clear_checkbox_name'] = conditional_escape(checkbox_name)
                 substitutions['clear_checkbox_id'] = conditional_escape(checkbox_id)
-                substitutions['clear'] = CheckboxInput().render(checkbox_name, False, attrs={'id': checkbox_id})
+                substitutions['clear'] = CheckboxInput().render(
+                    checkbox_name, False, attrs={'id': checkbox_id}, renderer=renderer)
                 substitutions['clear_template'] = self.template_with_clear % substitutions
 
         return mark_safe(template % substitutions)
@@ -61,7 +62,7 @@ class DatePickerWidget(DateInput):
     http://foundation-datepicker.peterbeno.com/example.html
     """
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """Extend the output to return a foundation-datepicker."""
 
         # Set a placeholder attribute - this should be the right thing
@@ -85,7 +86,7 @@ class DatePickerWidget(DateInput):
 
         return mark_safe(
             u'<div class="input-append">' +
-            super(DatePickerWidget, self).render(name, value, attrs) +
+            super(DatePickerWidget, self).render(name, value, attrs, renderer) +
             u'</div>'
             )
 
@@ -101,10 +102,10 @@ class TimePickerWidget(TimeInput):
     replace this with a time picker of some sort.
     """
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         """Extend the output to include a placeholder."""
 
         # Set a placeholder attribute
         attrs['placeholder'] = _('hh:mm')
 
-        return super(TimePickerWidget, self).render(name, value, attrs)
+        return super(TimePickerWidget, self).render(name, value, attrs, renderer)

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
-envlist = flake8, py{27,34}-{1.8,1.10,1.11}
+envlist = flake8, py{27,35}-1.11, py35-{2.1,2.2}
 
 [testenv]
 commands =
     flake8: flake8
-    py{27,34}: pip install -e .[test]
-    py{27,34}: python manage.py test {posargs}
+    py{27,35}: pip install -e .[test]
+    py{27,35}: python manage.py test {posargs}
 deps =
     flake8: flake8
-    py{27,34}: django-tastypie
-    1.8: Django>=1.8,<1.9
-    1.10: Django>=1.10,<1.11
-    1.11: git+https://github.com/django/django.git@stable/1.11.x#egg=django
+    py{27,35}: django-tastypie
+    1.11: Django>=1.11,<2.0
+    2.1: Django>=2.1,<2.2
+    2.2: Django>=2.2,<3.0
 passenv = CFLAGS DISPLAY
 setenv =
     SELENIUM_TESTS=1

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands =
 deps =
     flake8: flake8
     py{27,35}: django-tastypie
+    py{27,35}: {env:ES_TOX:}
     1.11: Django>=1.11,<2.0
     2.1: Django>=2.1,<2.2
     2.2: Django>=2.2,<3.0


### PR DESCRIPTION
This deals with all internal Django 2 deprecations, and the third party libraries it uses:
- [x] django-bleach - updated due to function move
- [x] Django-Select2: Released 4.3.2.2: https://github.com/mysociety/django-select2/commit/28c9bf981017d83836390b264a0fa8dd246e6a07
- [x] django-subdomain-instances: Released 3.0.1: https://github.com/mysociety/django-subdomain-instances/commit/a062ab56c760a440ab0f0d53edd68a8a9f48e64b and https://github.com/mysociety/django-subdomain-instances/commit/2b9f72313c005ea00e2d4810b35214acf110df53
- [x] popolo: https://github.com/mysociety/django-popolo/pull/16
- [x] sluggable: https://github.com/mysociety/django-sluggable/pull/2
- [x] django-haystack: Not sure how much of an issue this is. Currently pinned to 2.5, apparently 1.11 support only came in 2.7, but it appears to be running okay. Their changelog is non-existent/not great, I've skimmed the changes up to 2.8.1 and nothing majorly relevant appears to change, so I've updated it and will see.

Anyway, tests passing on Travis again, so more comfortable actually releasing this as a new version.